### PR TITLE
Changing applicationId to liev9000 for consistency with dev account

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "com.lie9000.tictactoe"
+        applicationId "com.liev9000.tictactoe"
         minSdkVersion 15
         targetSdkVersion 28
         versionCode 1

--- a/app/src/androidTest/java/com/liev9000/tictactoe/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/com/liev9000/tictactoe/ExampleInstrumentedTest.java
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 
-        assertEquals("com.lie9000.tictactoe", appContext.getPackageName());
+        assertEquals("com.liev9000.tictactoe", appContext.getPackageName());
     }
 }


### PR DESCRIPTION
I just realized we missed changing the package name in a couple of places.

See https://developer.android.com/studio/build/application-id for more info.